### PR TITLE
rgw: Adding SSE-S3 rgw options and support in GET and PUT paths 

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2697,6 +2697,125 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_crypt_s3_sse_backend
+  type: str
+  level: advanced
+  desc: Where the SSE-S3 encryption keys are stored. Supported KMS systems are OpenStack
+    Barbican ('barbican', the default) and HashiCorp Vault ('vault').
+  fmt_desc: Where the SSE-S3 encryption keys are stored. Supported KMS
+    systems are OpenStack Barbican (``barbican``, the default) and
+    HashiCorp Vault (``vault``).
+  default: barbican
+  services:
+  - rgw
+  enum_values:
+  - barbican
+  - vault
+  - testing
+  - kmip
+  with_legacy: true
+
+- name: rgw_crypt_s3_sse_vault_auth
+  type: str
+  level: advanced
+  desc: Type of authentication method to be used with SSE-S3 and Vault.
+  fmt_desc: Type of authentication method to be used. The only method
+    currently supported is ``token``.
+  default: token
+  services:
+  - rgw
+  see_also:
+  - rgw_crypt_s3_sse_backend
+  - rgw_crypt_s3_sse_vault_addr
+  - rgw_crypt_s3_sse_vault_token_file
+  enum_values:
+  - token
+  - agent
+  with_legacy: true
+- name: rgw_crypt_s3_sse_vault_token_file
+  type: str
+  level: advanced
+  desc: If authentication method is 'token', provide a path to the token file, which
+    for security reasons should readable only by Rados Gateway.
+  services:
+  - rgw
+  see_also:
+  - rgw_crypt_s3_sse_backend
+  - rgw_crypt_s3_sse_vault_auth
+  - rgw_crypt_s3_sse_vault_addr
+  with_legacy: true
+- name: rgw_crypt_s3_sse_vault_addr
+  type: str
+  level: advanced
+  desc: SSE-S3 Vault server base address.
+  fmt_desc: Vault server base address, e.g. ``http://vaultserver:8200``.
+  services:
+  - rgw
+  see_also:
+  - rgw_crypt_s3_sse_backend
+  - rgw_crypt_s3_sse_vault_auth
+  - rgw_crypt_s3_sse_vault_prefix
+  with_legacy: true
+# Optional URL prefix to Vault secret path
+- name: rgw_crypt_s3_sse_vault_prefix
+  type: str
+  level: advanced
+  desc: SSE-S3 Vault secret URL prefix, which can be used to restrict access to a particular
+    subset of the Vault secret space.
+  fmt_desc: The Vault secret URL prefix, which can be used to restrict access
+    to a particular subset of the secret space, e.g. ``/v1/secret/data``.
+  services:
+  - rgw
+  see_also:
+  - rgw_crypt_s3_sse_s3_backend
+  - rgw_crypt_s3_sse_vault_addr
+  - rgw_crypt_s3_sse_vault_auth
+  with_legacy: true
+#  Vault Namespace (only availabe in Vault Enterprise Version)
+- name: rgw_crypt_s3_sse_vault_namespace
+  type: str
+  level: advanced
+  desc: Vault Namespace to be used to select your tenant
+  fmt_desc: If set, Vault Namespace provides tenant isolation for teams and individuals
+    on the same Vault Enterprise instance, e.g. ``acme/tenant1``
+  services:
+  - rgw
+  see_also:
+  - rgw_crypt_s3_sse_s3_backend
+  - rgw_crypt_s3_sse_vault_auth
+  - rgw_crypt_s3_sse_vault_addr
+  with_legacy: true
+# Enable TLS authentication rgw and vault
+- name: rgw_crypt_s3_sse_vault_verify_ssl
+  type: bool
+  level: advanced
+  desc: Should RGW verify the vault server SSL certificate.
+  default: true
+  services:
+  - rgw
+  with_legacy: true
+# TLS certs options
+- name: rgw_crypt_s3_sse_vault_ssl_cacert
+  type: str
+  level: advanced
+  desc: Path for custom ca certificate for accessing vault server
+  services:
+  - rgw
+  with_legacy: true
+- name: rgw_crypt_s3_sse_vault_ssl_clientcert
+  type: str
+  level: advanced
+  desc: Path for custom client certificate for accessing vault server
+  services:
+  - rgw
+  with_legacy: true
+- name: rgw_crypt_s3_sse_vault_ssl_clientkey
+  type: str
+  level: advanced
+  desc: Path for private key required for client cert
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_list_bucket_min_readahead
   type: int
   level: advanced

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2697,7 +2697,7 @@ options:
   services:
   - rgw
   with_legacy: true
-- name: rgw_crypt_s3_sse_backend
+- name: rgw_crypt_sse_s3_backend
   type: str
   level: advanced
   desc: Where the SSE-S3 encryption keys are stored. Supported KMS systems are OpenStack
@@ -2715,7 +2715,7 @@ options:
   - kmip
   with_legacy: true
 
-- name: rgw_crypt_s3_sse_vault_auth
+- name: rgw_crypt_sse_s3_vault_auth
   type: str
   level: advanced
   desc: Type of authentication method to be used with SSE-S3 and Vault.
@@ -2725,14 +2725,14 @@ options:
   services:
   - rgw
   see_also:
-  - rgw_crypt_s3_sse_backend
-  - rgw_crypt_s3_sse_vault_addr
-  - rgw_crypt_s3_sse_vault_token_file
+  - rgw_crypt_sse_s3_backend
+  - rgw_crypt_sse_s3_vault_addr
+  - rgw_crypt_sse_s3_vault_token_file
   enum_values:
   - token
   - agent
   with_legacy: true
-- name: rgw_crypt_s3_sse_vault_token_file
+- name: rgw_crypt_sse_s3_vault_token_file
   type: str
   level: advanced
   desc: If authentication method is 'token', provide a path to the token file, which
@@ -2740,11 +2740,11 @@ options:
   services:
   - rgw
   see_also:
-  - rgw_crypt_s3_sse_backend
-  - rgw_crypt_s3_sse_vault_auth
-  - rgw_crypt_s3_sse_vault_addr
+  - rgw_crypt_sse_s3_backend
+  - rgw_crypt_sse_s3_vault_auth
+  - rgw_crypt_sse_s3_vault_addr
   with_legacy: true
-- name: rgw_crypt_s3_sse_vault_addr
+- name: rgw_crypt_sse_s3_vault_addr
   type: str
   level: advanced
   desc: SSE-S3 Vault server base address.
@@ -2752,12 +2752,12 @@ options:
   services:
   - rgw
   see_also:
-  - rgw_crypt_s3_sse_backend
-  - rgw_crypt_s3_sse_vault_auth
-  - rgw_crypt_s3_sse_vault_prefix
+  - rgw_crypt_sse_s3_backend
+  - rgw_crypt_sse_s3_vault_auth
+  - rgw_crypt_sse_s3_vault_prefix
   with_legacy: true
 # Optional URL prefix to Vault secret path
-- name: rgw_crypt_s3_sse_vault_prefix
+- name: rgw_crypt_sse_s3_vault_prefix
   type: str
   level: advanced
   desc: SSE-S3 Vault secret URL prefix, which can be used to restrict access to a particular
@@ -2767,12 +2767,12 @@ options:
   services:
   - rgw
   see_also:
-  - rgw_crypt_s3_sse_s3_backend
-  - rgw_crypt_s3_sse_vault_addr
-  - rgw_crypt_s3_sse_vault_auth
+  - rgw_crypt_sse_s3_backend
+  - rgw_crypt_sse_s3_vault_addr
+  - rgw_crypt_sse_s3_vault_auth
   with_legacy: true
 #  Vault Namespace (only availabe in Vault Enterprise Version)
-- name: rgw_crypt_s3_sse_vault_namespace
+- name: rgw_crypt_sse_s3_vault_namespace
   type: str
   level: advanced
   desc: Vault Namespace to be used to select your tenant
@@ -2781,12 +2781,12 @@ options:
   services:
   - rgw
   see_also:
-  - rgw_crypt_s3_sse_s3_backend
-  - rgw_crypt_s3_sse_vault_auth
-  - rgw_crypt_s3_sse_vault_addr
+  - rgw_crypt_sse_s3_backend
+  - rgw_crypt_sse_s3_vault_auth
+  - rgw_crypt_sse_s3_vault_addr
   with_legacy: true
 # Enable TLS authentication rgw and vault
-- name: rgw_crypt_s3_sse_vault_verify_ssl
+- name: rgw_crypt_sse_s3_vault_verify_ssl
   type: bool
   level: advanced
   desc: Should RGW verify the vault server SSL certificate.
@@ -2795,21 +2795,21 @@ options:
   - rgw
   with_legacy: true
 # TLS certs options
-- name: rgw_crypt_s3_sse_vault_ssl_cacert
+- name: rgw_crypt_sse_s3_vault_ssl_cacert
   type: str
   level: advanced
   desc: Path for custom ca certificate for accessing vault server
   services:
   - rgw
   with_legacy: true
-- name: rgw_crypt_s3_sse_vault_ssl_clientcert
+- name: rgw_crypt_sse_s3_vault_ssl_clientcert
   type: str
   level: advanced
   desc: Path for custom client certificate for accessing vault server
   services:
   - rgw
   with_legacy: true
-- name: rgw_crypt_s3_sse_vault_ssl_clientkey
+- name: rgw_crypt_sse_s3_vault_ssl_clientkey
   type: str
   level: advanced
   desc: Path for private key required for client cert

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -16,6 +16,7 @@
 #include "crypto/crypto_accel.h"
 #include "crypto/crypto_plugin.h"
 #include "rgw/rgw_kms.h"
+#include "rgw/rgw_bucket_encryption.h"
 #include "rapidjson/document.h"
 #include "rapidjson/writer.h"
 #include "rapidjson/error/error.h"
@@ -904,6 +905,7 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
 {
   int res = 0;
   crypt_http_responses.clear();
+
   {
     std::string_view req_sse_ca =
         get_crypt_attribute(s->info.env, parts, X_AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM);
@@ -1087,6 +1089,78 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
         s->err.message = "Server Side Encryption with KMS managed key requires "
                          "HTTP header x-amz-server-side-encryption : aws:kms";
         return -EINVAL;
+      }
+    }
+
+    /* Checking bucket attributes if SSE is enabled. Currently only supporting SSE-S3 */
+    rgw::sal::Attrs buck_attrs(s->bucket_attrs);
+    auto aiter = buck_attrs.find(RGW_ATTR_BUCKET_ENCRYPTION_POLICY);
+    if (aiter != buck_attrs.end()) {
+      ldpp_dout(s, 5) << "Found RGW_ATTR_BUCKET_ENCRYPTION_POLICY on "
+	      << s->bucket_name << dendl;
+
+      bufferlist::const_iterator iter{&aiter->second};
+      try {
+        RGWBucketEncryptionConfig bucket_encryption_conf;
+	bucket_encryption_conf.decode(iter);
+	if (bucket_encryption_conf.sse_algorithm() == "AES256") {
+	  ldpp_dout(s, 5) << "RGW_ATTR_BUCKET_ENCRYPTION ALGO: "
+		  <<  bucket_encryption_conf.sse_algorithm() << dendl;
+	  std::string_view context = "";
+          std::string cooked_context;
+	  if ((res = make_canonical_context(s, context, cooked_context)))
+	    return res;
+
+	  /* Find the KEK ID */
+	  auto kek_iter = buck_attrs.find(RGW_ATTR_BUCKET_ENCRYPTION_KEY_ID);
+	  if (kek_iter == buck_attrs.end()) {
+	    ldpp_dout(s, 5) << "ERROR: KEK ID absent for bucket having "
+		    "encryption enabled" << dendl;
+	    s->err.message = "Server side error - SSE-S3 key absent";
+	    return -EINVAL;
+	  }
+
+	  std::string_view key_id = kek_iter->second.to_str();
+	  ldpp_dout(s, 5) << "Found KEK ID: " << key_id << dendl;
+	  std::string key_selector = create_random_key_selector(s->cct);
+
+	  set_attr(attrs, RGW_ATTR_CRYPT_KEYSEL, key_selector);
+	  set_attr(attrs, RGW_ATTR_CRYPT_CONTEXT, cooked_context);
+	  set_attr(attrs, RGW_ATTR_CRYPT_MODE, "AES256");
+	  set_attr(attrs, RGW_ATTR_CRYPT_KEYID, key_id);
+	  std::string actual_key;
+	  res = make_actual_key_from_sse_s3(s->cct, attrs, actual_key);
+          if (res != 0) {
+	    ldpp_dout(s, 5) << "ERROR: failed to retrieve actual key from key_id: " << key_id << dendl;
+	    s->err.message = "Failed to retrieve the actual key " ;
+	    return res;
+	  }
+	  if (actual_key.size() != AES_256_KEYSIZE) {
+	    ldpp_dout(s, 5) << "ERROR: key obtained from key_id:" <<
+                           key_id << " is not 256 bit size" << dendl;
+	    s->err.message = "SSE-S3 provided an invalid key for the given keyid.";
+	    return -ERR_INVALID_ACCESS_KEY;
+	  }
+
+          if (block_crypt) {
+	    auto aes = std::unique_ptr<AES_256_CBC>(new AES_256_CBC(s->cct));
+	    aes->set_key(reinterpret_cast<const uint8_t*>(actual_key.c_str()), AES_256_KEYSIZE);
+	    *block_crypt = std::move(aes);
+	  }
+          ::ceph::crypto::zeroize_for_security(actual_key.data(), actual_key.length());
+
+	  crypt_http_responses["x-amz-server-side-encryption"] = "AES256";
+
+	  return 0;
+	} else {
+          ldpp_dout(s, 5) << "ERROR: SSE algorithm: "
+		  <<  bucket_encryption_conf.sse_algorithm()
+		  << " not supported" << dendl;
+	  s->err.message = "The requested encryption algorithm is not valid, must be AES256.";
+	  return -ERR_INVALID_ENCRYPTION_ALGORITHM;
+	}
+      } catch (const buffer::error& e) {
+        ldpp_dout(s, 5) << __func__ <<  "decode bucket_encryption_conf failed" << dendl;
       }
     }
 
@@ -1300,6 +1374,40 @@ int rgw_s3_prepare_decrypt(struct req_state* s,
     if (block_crypt) *block_crypt = std::move(aes);
     return 0;
   }
+
+  /* SSE-S3 */
+  if (stored_mode == "AES256") {
+    if (s->cct->_conf->rgw_crypt_require_ssl &&
+        !rgw_transport_is_secure(s->cct, *s->info.env)) {
+      ldpp_dout(s, 5) << "ERROR: Insecure request, rgw_crypt_require_ssl is set" << dendl;
+      return -ERR_INVALID_REQUEST;
+    }
+    /* try to retrieve actual key */
+    std::string key_id = get_str_attribute(attrs, RGW_ATTR_CRYPT_KEYID);
+    std::string actual_key;
+    res = reconstitute_actual_key_from_sse_s3(s->cct, attrs, actual_key);
+    if (res != 0) {
+      ldpp_dout(s, 10) << "ERROR: failed to retrieve actual key  " << dendl;
+      s->err.message = "Failed to retrieve the actual key " ;
+      return res;
+    }
+    if (actual_key.size() != AES_256_KEYSIZE) {
+      ldpp_dout(s, 0) << "ERROR: key obtained " <<
+          " is not 256 bit size" << dendl;
+      s->err.message = "SSE-S3  provided an invalid key for the given keyid.";
+      return -ERR_INVALID_ACCESS_KEY;
+    }
+
+    auto aes = std::unique_ptr<AES_256_CBC>(new AES_256_CBC(s->cct));
+    aes->set_key(reinterpret_cast<const uint8_t*>(actual_key.c_str()), AES_256_KEYSIZE);
+    actual_key.replace(0, actual_key.length(), actual_key.length(), '\000');
+    if (block_crypt) *block_crypt = std::move(aes);
+
+    crypt_http_responses["x-amz-server-side-encryption"] = "AES256";
+    return 0;
+  }
+
+
   /*no decryption*/
   return 0;
 }

--- a/src/rgw/rgw_kms.h
+++ b/src/rgw/rgw_kms.h
@@ -37,6 +37,12 @@ int make_actual_key_from_kms(CephContext *cct,
 int reconstitute_actual_key_from_kms(CephContext *cct,
                             map<string, bufferlist>& attrs,
                             std::string& actual_key);
+int make_actual_key_from_sse_s3(CephContext *cct,
+                            map<string, bufferlist>& attrs,
+                            std::string& actual_key);
+int reconstitute_actual_key_from_sse_s3(CephContext *cct,
+                            map<string, bufferlist>& attrs,
+                            std::string& actual_key);
 
 /**
  * SecretEngine Interface

--- a/src/rgw/rgw_kms.h
+++ b/src/rgw/rgw_kms.h
@@ -43,6 +43,7 @@ int make_actual_key_from_sse_s3(CephContext *cct,
 int reconstitute_actual_key_from_sse_s3(CephContext *cct,
                             map<string, bufferlist>& attrs,
                             std::string& actual_key);
+int generate_kek_sse_s3(CephContext *cct, string kek_id);
 
 /**
  * SecretEngine Interface

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -51,6 +51,7 @@
 #include "rgw_notify_event_type.h"
 #include "rgw_sal.h"
 #include "rgw_sal_rados.h"
+#include "rgw_kms.h"
 
 #include "services/svc_zone.h"
 #include "services/svc_quota.h"
@@ -8616,6 +8617,14 @@ void RGWPutBucketEncryption::execute(optional_yield y)
   bufferlist key_id_bl;
   string bucket_owner_id = s->bucket->get_info().owner.id;
   key_id_bl.append(bucket_owner_id.c_str(), bucket_owner_id.size() + 1);
+
+  /* Generating KEK on the vault */
+  ldpp_dout(this, 5) << "Generating KEK: " << bucket_owner_id << dendl;
+  op_ret = generate_kek_sse_s3(s->cct, bucket_owner_id);
+  if (op_ret < 0) {
+    ldpp_dout(this, 20) << "Generate KEK returned =" << op_ret << dendl;
+    return;
+  }
 
   bufferlist conf_bl;
   bucket_encryption_conf.encode(conf_bl);


### PR DESCRIPTION
 rgw: Adding SSE-S3 support in GET and PUT paths (using Vault as KMS)

In this patch, we introduce the SSE-S3 RGW options and use them in GET and PUT paths.
We generate the KEK based on bucket owner UID in PutBucketEncryption.
In the PUT path, we check if BucketEncryption is enabled for the bucket.
If yes, we detemine if the encryption type is AES256 (i.e., SSE-S3),
then we fetch the KEK-ID from the bucket x-attrs and use it to wrap the
data key. Thereafter, we call generate-data-key. We store the KEK-ID
and the wrapped data-key in the object x-attrs.
In the GET path, we simply pull out the KEK-ID from the object x-attr and
decrypt the object.

Signed-off-by: Priya Sehgal <priya.sehgal@flipkart.com>